### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ However, if you have a multifasta file, the appropriate command line is:
 
     bash pasteTaxID.bash --multifasta [multifasta_file]
 
-where `--workpath` is a directory where your fasta files are located and `--multifasta` is the multifasta file (.fna, .fn or .fasta works too). 
+where `--workdir` is a directory where your fasta files are located and `--multifasta` is the multifasta file (.fna, .fn or .fasta works too). 
 
 In the example folder there are some fasta files that don't contain a gi or a ti, just gb. Try testing the script by issuing
 


### PR DESCRIPTION
Use correct command line argument in explanation.